### PR TITLE
Upgrade npm package, time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -128,6 +128,11 @@
         "tweetnacl": "0.14.5"
       }
     },
+    "bindings": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
+      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
+    },
     "bluebird": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
@@ -254,7 +259,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -1709,8 +1713,12 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "nan": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
     },
     "node-uuid": {
       "version": "1.4.8",
@@ -2216,38 +2224,13 @@
       "dev": true
     },
     "time": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/time/-/time-0.11.4.tgz",
-      "integrity": "sha1-7DyJR9f6SI87GXi4EQpoGG9dNA8=",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/time/-/time-0.12.0.tgz",
+      "integrity": "sha1-dVQUvD7woupEzp93W9PPZk7Em7c=",
       "requires": {
-        "bindings": "1.2.1",
+        "bindings": "1.3.0",
         "debug": "2.6.9",
-        "nan": "2.7.0"
-      },
-      "dependencies": {
-        "bindings": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-          "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "nan": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-          "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
-        }
+        "nan": "2.10.0"
       }
     },
     "tough-cookie": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "hubot-scripts": "^2.17.2",
     "hubot-shipit": "^0.2.1",
     "request": "^2.81.0",
-    "time": "^0.11.4"
+    "time": "^0.12.0"
   },
   "engines": {
     "node": "9.5.0"


### PR DESCRIPTION
```
  CXX(target) Release/obj.target/time/src/time.o
In file included from ../src/time.cc:5:
In file included from ../node_modules/nan/nan.h:192:
../node_modules/nan/nan_maybe_43_inl.h:112:15: warning: 'ForceSet' is deprecated [-Wdeprecated-declarations]
  return obj->ForceSet(isolate->GetCurrentContext(), key, value, attribs);
              ^
/Users/kojimamayu/.node-gyp/9.5.0/include/node/v8.h:3114:3: note: 'ForceSet' has been explicitly marked deprecated
      here
  V8_DEPRECATED("Use CreateDataProperty / DefineOwnProperty",
  ^
/Users/kojimamayu/.node-gyp/9.5.0/include/node/v8config.h:321:29: note: expanded from macro 'V8_DEPRECATED'
  declarator __attribute__((deprecated))
                            ^
1 warning generated.
  SOLINK_MODULE(target) Release/time.node
```

`npm install`で上記のwarningが発生したので、ncuを使って修正。

```
ncu -u
npm update time --save-dev
```